### PR TITLE
reduxでdeletedotアクションを作成 #76

### DIFF
--- a/src/components/templates/Dots.jsx
+++ b/src/components/templates/Dots.jsx
@@ -1,39 +1,54 @@
 import React from "react";
+import { useDispatch } from "react-redux";
 import ListItemText from "@material-ui/core/ListItemText";
 import Divider from "@material-ui/core/Divider";
 import { makeStyles } from "@material-ui/core/styles";
 import { Link } from "react-router-dom";
 import firebase from "../../firebase/firebase";
+import { delete_dot } from "../../reducks/dots/action";
 
 const useStyles = makeStyles((theme) => ({
-  primary: {
-    whiteSpace: "nowrap",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-  },
+	primary: {
+		whiteSpace: "nowrap",
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+	},
 }));
 
 export default function Dots({ dot }) {
-  const classes = useStyles();
-  const handle_delete = () => {
-    firebase.firestore().collection("dots").doc(dot.dotId).delete().then(function () {
-      console.log("Document successfully deleted!");
-    }).catch(function (error) {
-      console.error("Error removing document: ", error);
-    });
-  }
-  return (
-    <div>
-      <Link style={{ display: "flex" }} to={`/dot/${dot.dotId}`}>
-        <ListItemText
-          className={classes.list}
-          primary={dot.title}
-          classes={{ primary: classes.primary }}
-        />
+	const classes = useStyles();
 
-      </Link>
-      <button onClick={handle_delete}>削除</button>
-      <Divider />
-    </div>
-  );
+	const dispatch = useDispatch();
+
+	const handle_delete = () => {
+		// -----画面上からdotを消す-----//
+		dispatch(delete_dot(dot));
+
+		// -----firebaseからdotを消す-----//
+		firebase
+			.firestore()
+			.collection("dots")
+			.doc(dot.dotId)
+			.delete()
+			.then(function () {
+				console.log("Document successfully deleted!");
+			})
+			.catch(function (error) {
+				console.error("Error removing document: ", error);
+			});
+	};
+
+	return (
+		<div>
+			<Link style={{ display: "flex" }} to={`/dot/${dot.dotId}`}>
+				<ListItemText
+					className={classes.list}
+					primary={dot.title}
+					classes={{ primary: classes.primary }}
+				/>
+			</Link>
+			<button onClick={handle_delete}>削除</button>
+			<Divider />
+		</div>
+	);
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,13 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
-import { applyMiddleware, compose } from "redux";
-import reduxThunk from "redux-thunk";
 import App from "./App";
 import createStore from "./reducks/store/store";
 
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; //Redux DevToolsを使うために定義
-export const store = createStore(composeEnhancers(applyMiddleware(reduxThunk)));
+export const store = createStore();
 
 ReactDOM.render(
 	<Provider store={store}>

--- a/src/reducks/dots/action.jsx
+++ b/src/reducks/dots/action.jsx
@@ -13,3 +13,11 @@ export const fetch_dot = (dot) => {
 		payload: dot,
 	};
 };
+
+export const DELETE_DOT = "DELETE_DOT";
+export const delete_dot = (dot) => {
+	return {
+		type: DELETE_DOT,
+		payload: dot,
+	};
+};

--- a/src/reducks/dots/reducers.jsx
+++ b/src/reducks/dots/reducers.jsx
@@ -7,6 +7,9 @@ export const DotReducer = (state = initialState, action) => {
 			return [...state, action.payload];
 		case Actions.FETCH_DOT:
 			return action.payload;
+		case Actions.DELETE_DOT:
+			return state.filter((dot) => dot !== action.payload);
+
 		default:
 			return state;
 	}

--- a/src/reducks/store/store.jsx
+++ b/src/reducks/store/store.jsx
@@ -1,10 +1,13 @@
-import { createStore as reduxCreateStore, combineReducers } from "redux";
+import { createStore as reduxCreateStore, combineReducers, compose, applyMiddleware } from "redux";
 import { DotReducer } from "../dots/reducers";
+import reduxThunk from "redux-thunk";
 
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; //Redux DevToolsを使うために定義
 export default function createStore() {
 	return reduxCreateStore(
 		combineReducers({
 			dots: DotReducer,
-		})
+		}),
+		composeEnhancers(applyMiddleware(reduxThunk))
 	);
 }


### PR DESCRIPTION
## Issue

Closes #76 

## 今回の PR で行ったこと

reduxでdeleteDotの作成。
…消去ボタンをredux管理にし、消去ボタンを押すことでその内容が画面から消えるように設定＆firebaseからも消すことで再起動後も消えているように設定。
-

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

行ったこと→結果
・title入力→きちんと表示される
・表示された内容をクリック→正しくページに飛ぶ
・消去ボタンクリック→ちゃんと指定のものだけ消える
・ログアウト後再びBaseページ見る→きちんと消去した内容だけ消えている
全体的に問題なく消去ボタンは稼働しているかと思います。

-

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

・action.jsx
・reducer.jsx
・store.jsx (redux devToolを使えるようにする実装をindex.jsxで上手くできていなかったので、storeに変えました)
・index.js(上記の理由により)
・Dots.jsx

## 実装するにあたって参考にした URL

https://reffect.co.jp/react/react-redux-todo#i-4
-

## 確認して欲しいこと

-

## 懸念点

fiarebaseからデータを消すタイミング、その実装について。
・タイミング
データを取得するfetch_dotsはApp.jsxで行った。
今回も上位のコンポーネントで行おうかと思った。しかし今回は、消去ボタンをクリックしたときに、クリックされた内容を消すことが求められているため、このボタンのonClickが書かれているコンポーネントで行うべきかと判断。しかしもっと適切な実装箇所があるのではないかと懸念しています。

・実装
firebaseからdotを消す実装は、firebaseから何かデータを貰ってくるような実装ではないため、storeで保管するものではないと判断。その判断に基づき、firebaseからdotを消す用のactionは作っていません。その代わり、消去ボタンをクリックしたときに、そのクリックしたdotをその場で消すように実装しています。
fetchDotの際はfirebase用と、その場の画面表示用と2つのactionを作ったので、この判断が的確だったのか懸念しています。



-
